### PR TITLE
Automatically restore binary from string in protocol <= 2

### DIFF
--- a/lib/unpickler.ex
+++ b/lib/unpickler.ex
@@ -849,6 +849,11 @@ defmodule Unpickler do
     end
   end
 
+  defp built_in_resolver(%{constructor: "_codecs.encode", args: [binary, "latin1"]}) do
+    # In protocol <= 2 bytes are stored as a string and deserialized by encoding
+    {:ok, :unicode.characters_to_binary(binary, :utf8, :latin1)}
+  end
+
   defp built_in_resolver(_), do: :error
 
   defp read_line(binary) do

--- a/test/unpickler_test.exs
+++ b/test/unpickler_test.exs
@@ -459,4 +459,13 @@ defmodule UnpicklerTest do
 
     assert Unpickler.load!(data) == {%Unpickler.Global{scope: "datetime", name: "date"}, ""}
   end
+
+  test "protocol 1 bytes" do
+    data =
+      <<99, 95, 99, 111, 100, 101, 99, 115, 10, 101, 110, 99, 111, 100, 101, 10, 113, 0, 40, 88,
+        3, 0, 0, 0, 195, 191, 1, 113, 1, 88, 6, 0, 0, 0, 108, 97, 116, 105, 110, 49, 113, 2, 116,
+        113, 3, 82, 113, 4, 46>>
+
+    assert Unpickler.load!(data) == {<<255, 1>>, ""}
+  end
 end


### PR DESCRIPTION
Protocols <= 2 don't support bytes directly, instead they are stored as a string and then encoded with a function call on load.